### PR TITLE
minor changes to adapt Windows build 

### DIFF
--- a/freeline_core/android_tools.py
+++ b/freeline_core/android_tools.py
@@ -313,6 +313,8 @@ class AndroidIncBuildInvoker(object):
 
         self._aapt = Builder.get_aapt()
         self._javac = Builder.get_javac()
+        if self._javac is None:
+            raise FreelineException('Please declares your JAVA_HOME to system env!')
         self._dx = Builder.get_dx(self._config)
         self._cache_dir = self._config['build_cache_dir']
         self._finder = None

--- a/freeline_core/logger.py
+++ b/freeline_core/logger.py
@@ -171,7 +171,7 @@ class Logger(object):
 
 
 def get_error_log_path():
-    return os.path.join(get_error_log_dir(), time.strftime('%y-%m-%d %H:%M:%S') + '.log')
+    return os.path.join(get_error_log_dir(), time.strftime('%y-%m-%d %H-%M-%S') + '.log')
 
 
 def get_error_log_dir():

--- a/gradle/src/main/groovy/com/antfortune/freeline/FreelineGenerator.groovy
+++ b/gradle/src/main/groovy/com/antfortune/freeline/FreelineGenerator.groovy
@@ -18,7 +18,7 @@ class FreelineGenerator {
     public static String generateBuildScript(String productFlavor) {
         def params = []
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            params.add("gradle.bat")
+            params.add("gradlew.bat")
         } else {
             params.add("./gradlew")
         }


### PR DESCRIPTION
1. `gradle/src/main/groovy/com/antfortune/freeline/FreelineGenerator.groovy` 的`generateBuildScript()`在windows上是错的
2. `freeline_core/logger.py`，输出的log文件名格式，很遗憾windows不支持`:`
3. `freeline_core/android_tools.py` 应该明确告知找不到 `javac` ，否则会在后面报令人疑惑的错误信息`TypeError: sequence item 0: expected string, NoneType found`