### PR TITLE
grade插件直接依赖runtime，不需要用户添加依赖

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,6 @@ android {
     }
 }
 
-dependencies {
-  debugCompile 'com.antfortune.freeline:runtime:0.6.1'
-  releaseCompile 'com.antfortune.freeline:runtime-no-op:0.6.1'
-  testCompile 'com.antfortune.freeline:runtime-no-op:0.6.1'
-}
 ````
 Finally, apply freeline in your application class.
 

--- a/gradle/src/main/groovy/com/antfortune/freeline/FreelinePlugin.groovy
+++ b/gradle/src/main/groovy/com/antfortune/freeline/FreelinePlugin.groovy
@@ -17,6 +17,12 @@ class FreelinePlugin implements Plugin<Project> {
 
         project.extensions.create("freeline", FreelineExtension, project)
 
+        project.dependencies {
+            debugCompile 'com.antfortune.freeline:runtime:0.6.2'
+            releaseCompile 'com.antfortune.freeline:runtime-no-op:0.6.2'
+            testCompile 'com.antfortune.freeline:runtime-no-op:0.6.2'
+        }
+
         project.rootProject.task("initFreeline") << {
             FreelineInitializer.initFreeline(project)
         }


### PR DESCRIPTION
RT，grade插件直接依赖runtime，不需要用户添加依赖。
```
freeline {
        hack true
    }
```
为什么hack不默认设置为true呢？还需要用户自己设置下？