### PR TITLE
修改了gradle插件依赖的gradle地址以及maven的使用

### DIFF
--- a/android-studio-plugin/resources/META-INF/plugin.xml
+++ b/android-studio-plugin/resources/META-INF/plugin.xml
@@ -72,7 +72,7 @@
 
     <actions>
         <!-- Freeline default run action -->
-        <action id="Plugin_FreeLine_Run" class="actions.FreeLineRunAction"
+        <action id="Plugin_Freeline_Run" class="actions.FreelineRunAction"
                 text="Run Freeline" description="Run Freeline"
                 icon="PluginIcons.FreelineIcon">
             <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
@@ -85,18 +85,18 @@
         </group>
 
         <!-- Freeline tools -->
-        <group id="Plugin_FreeLine_Tools" text="Freeline" description="Freeline" popup="true">
-            <action id="Plugin_FreeLine_Run_Debug" class="actions.DebugRunAction" text="Run Freeline Debug"
-                    description="Run FreeLine Debug"
+        <group id="Plugin_Freeline_Tools" text="Freeline" description="Freeline" popup="true">
+            <action id="Plugin_Freeline_Run_Debug" class="actions.DebugRunAction" text="Run Freeline Debug"
+                    description="Run Freeline Debug"
                     icon="PluginIcons.StartDebugger">
             </action>
             <separator/>
-            <action id="Plugin_FreeLine_Run_Force" class="actions.ForceRunAction" text="Run Freeline Force"
-                    description="Run FreeLine Force"
+            <action id="Plugin_Freeline_Run_Force" class="actions.ForceRunAction" text="Run Freeline Force"
+                    description="Run Freeline Force"
                     icon="PluginIcons.QuickfixBulb">
             </action>
             <separator/>
-            <action id="Plugin_FreeLine_Run_Update" class="actions.UpdateAction" text="Check Freeline Update"
+            <action id="Plugin_Freeline_Run_Update" class="actions.UpdateAction" text="Check Freeline Update"
                     description="Check Update"
                     icon="PluginIcons.GradleSync">
             </action>

--- a/android-studio-plugin/src/actions/BaseAction.java
+++ b/android-studio-plugin/src/actions/BaseAction.java
@@ -36,16 +36,16 @@ public abstract class BaseAction extends AnAction {
     public abstract void actionPerformed();
 
     /**
-     * 检查FreeLine是否存在
+     * 检查Freeline是否存在
      *
      * @return
      */
-    protected boolean checkFreeLineExist() {
+    protected boolean checkFreelineExist() {
         File pyFile = new File(projectDir, "freeline.py");
         if (pyFile.exists()) {
             return true;
         }
-        NotificationUtils.errorNotification("please install FreeLine first");
+        NotificationUtils.errorNotification("please install Freeline first");
         return false;
     }
 

--- a/android-studio-plugin/src/actions/DebugRunAction.java
+++ b/android-studio-plugin/src/actions/DebugRunAction.java
@@ -3,7 +3,7 @@ package actions;
 /**
  * Created by pengwei on 16/9/11.
  */
-public class DebugRunAction extends FreeLineRunAction {
+public class DebugRunAction extends FreelineRunAction {
     @Override
     protected String getArgs() {
         return "-d";

--- a/android-studio-plugin/src/actions/ForceRunAction.java
+++ b/android-studio-plugin/src/actions/ForceRunAction.java
@@ -3,7 +3,7 @@ package actions;
 /**
  * Created by pengwei on 16/9/11.
  */
-public class ForceRunAction extends FreeLineRunAction {
+public class ForceRunAction extends FreelineRunAction {
     @Override
     protected String getArgs() {
         return "-f";

--- a/android-studio-plugin/src/actions/FreelineRunAction.java
+++ b/android-studio-plugin/src/actions/FreelineRunAction.java
@@ -7,10 +7,10 @@ import views.FreelineTerminal;
 /**
  * Created by pengwei on 16/9/11.
  */
-public class FreeLineRunAction extends BaseAction {
+public class FreelineRunAction extends BaseAction {
     @Override
     public void actionPerformed() {
-        if (checkFreeLineExist()) {
+        if (checkFreelineExist()) {
             String python = Utils.getPythonLocation();
             if (python == null) {
                 NotificationUtils.errorNotification("command 'python' not found");

--- a/android-studio-plugin/src/actions/UpdateAction.java
+++ b/android-studio-plugin/src/actions/UpdateAction.java
@@ -37,7 +37,7 @@ public class UpdateAction extends BaseAction implements GetServerCallback {
 
     @Override
     public void actionPerformed() {
-        if (checkFreeLineExist()) {
+        if (checkFreelineExist()) {
             asyncTask(new GetServerVersion(this));
         } else {
             GradleUtil.executeTask(currentProject, "initFreeline", "-Pmirror", null);

--- a/android-studio-plugin/src/utils/NotificationUtils.java
+++ b/android-studio-plugin/src/utils/NotificationUtils.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.application.ApplicationManager;
 
 public class NotificationUtils {
 
-    private static final String TITLE = "FreeLine Plugin";
+    private static final String TITLE = "Freeline Plugin";
     private static final NotificationGroup NOTIFICATION_GROUP = NotificationGroup.balloonGroup(TITLE);
 
     /**

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.jfrog.bintray'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven'
 
 def mavenDesc = 'Freeline is an incremental build tool for Android platform.'
 def siteUrl = 'https://github.com/alibaba/freeline'

--- a/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://mirrors.taobao.net/mirror/gradle/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -7,3 +7,6 @@
 /build
 /captures
 .idea
+freeline/
+freeline_core/
+freeline.py


### PR DESCRIPTION
1.修改了gradle插件依赖的gradle地址以及maven的使用
2.忽略sample下freeline自动生成的文件

`com.github.dcendents.android-maven` 主要用于AAR的，普通的Java工程直接用`maven`就可以了