### PR TITLE
Support md5 check for core file

### DIFF
--- a/freeline_core/android_tools.py
+++ b/freeline_core/android_tools.py
@@ -9,7 +9,7 @@ from logger import Logger
 from builder import Builder
 from task import Task, SyncTask, IncrementalBuildTask
 from utils import cexec, write_file_content, get_file_content, merge_xml, get_md5, load_json_cache, is_windows_system, \
-    write_json_cache, calculate_typed_file_count, remove_namespace
+    write_json_cache, calculate_typed_file_count, remove_namespace, read_content
 from command import AbstractCommand
 from exceptions import FreelineException
 from sync_client import SyncClient
@@ -180,7 +180,16 @@ class UpdateStatTask(Task):
                             stat_cache[module][fpath]['size'] = os.path.getsize(fpath)
 
         write_json_cache(cache_path, stat_cache)
-
+        cache_path_md5 = os.path.join(self._config['build_cache_dir'], 'stat_cache_md5.json')
+        stat_cache_md5 = load_json_cache(cache_path_md5)
+        if 'use_md5_paths' in self._config and self._config['use_md5_paths'] is not None:
+                    arr = self._config['use_md5_paths']
+                    for path in arr:
+                        path = path.strip()
+                        #read content,Generate MD5
+                        md5 = get_md5(path);
+                        stat_cache_md5[path] = md5
+        write_json_cache(cache_path_md5, stat_cache_md5)
 
 class DirectoryFinder(object):
     def __init__(self, module_name, cache_dir):

--- a/freeline_core/dispatcher.py
+++ b/freeline_core/dispatcher.py
@@ -152,7 +152,7 @@ def version():
 
 
 def get_cache_dir():
-    cache_dir_path = os.path.join(os.path.expanduser('~'), '.freeline', 'cache', md5string(os.getcwd().decode("utf-8")))
+    cache_dir_path = os.path.join(os.getcwd())
     if not os.path.exists(cache_dir_path):
         os.makedirs(cache_dir_path)
     return cache_dir_path
@@ -160,7 +160,7 @@ def get_cache_dir():
 
 def read_freeline_config(config_path=None):
     if not config_path:
-        config_path = os.path.join(os.getcwd(), 'freeline_project_description.json')
+        config_path = os.path.join(get_cache_dir(), 'freeline_project_description.json')
 
     if os.path.isfile(config_path):
         config = load_json_cache(config_path)

--- a/freeline_core/freeline_build.py
+++ b/freeline_core/freeline_build.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from command import AbstractCommand
 from exceptions import NoConfigFoundException
 from logger import Logger
+from utils import load_json_cache
 
 
 class FreelineBuildCommand(AbstractCommand):
@@ -19,6 +20,7 @@ class FreelineBuildCommand(AbstractCommand):
 
     def execute(self):
         file_changed_dict = self._scan_command.execute()
+        file_changed_md5_dict = self._setup_get_file_changed_bymd5()
 
         if self._dispatch_policy.is_need_clean_build(self._config, file_changed_dict):
             self._setup_clean_builder(file_changed_dict)
@@ -33,6 +35,11 @@ class FreelineBuildCommand(AbstractCommand):
             self._build_command = IncrementalBuildCommand(self._builder)
 
         self._build_command.execute()
+
+    def _setup_get_file_changed_bymd5(self):
+          if self._project_type == 'gradle':
+              file_changed_md5_dict = load_json_cache(self._config['build_cache_dir'] + 'stat_cache_md5.json')
+          return file_changed_md5_dict
 
     def _setup(self):
         if not self._config:

--- a/freeline_core/gradle_clean_build.py
+++ b/freeline_core/gradle_clean_build.py
@@ -39,7 +39,7 @@ class GradleCleanBuilder(CleanBuilder):
         build_task = GradleCleanBuildTask(self._config)
         install_task = InstallApkTask(self._adb, self._config, wait_for_debugger=self._wait_for_debugger)
         clean_all_cache_task = CleanAllCacheTask(self._config['build_cache_dir'], ignore=[
-            'stat_cache.json', 'apktime', 'jar_dependencies.json', 'resources_dependencies.json', 'public_keeper.xml',
+            'stat_cache.json','stat_cache_md5.json', 'apktime', 'jar_dependencies.json', 'resources_dependencies.json', 'public_keeper.xml',
             'assets_dependencies.json', 'freeline_annotation_info.json'])
         build_base_resource_task = BuildBaseResourceTask(self._config, self._project_info)
         generate_stat_task = GenerateFileStatTask(self._config)

--- a/freeline_core/utils.py
+++ b/freeline_core/utils.py
@@ -165,6 +165,34 @@ def get_text_by_tag(root, tag):
     element = root.find(tag)
     return element.text if element is not None else ''
 
+def if_file_change_by_md5(fpath, compare_time, md5):
+    last_clean_build_time = os.path.getmtime(fpath) if os.path.exists(fpath) else 0
+    if (os.path.getmtime(os.path.join(fpath)) <= compare_time):
+        return False
+    is_change = get_md5(fpath) != md5
+    print('path:'+fpath+',time change,and md5 result is:'+str(is_change))
+    return is_change
+
+def read_content(fpath):
+    if not os.path.exists(fpath):
+        pass
+    if os.path.isfile(fpath):
+        try:
+            file_object = open(fpath)
+            content = file_object.read()
+        except Exception:
+            pass
+        finally:
+            file_object.close()
+    return content
+
+#判断路径下是否含有输入路径，如果有则返回，没有返回null
+def array_has_path(md5_array,fpath):
+    for str in md5_array:
+       if str.replace('//','').lower() == fpath.replace('//','').lower():
+           return str
+    return None
+
 
 class HashableDict(dict):
     def __hash__(self):

--- a/gradle/src/main/groovy/com/antfortune/freeline/FreelineExtension.groovy
+++ b/gradle/src/main/groovy/com/antfortune/freeline/FreelineExtension.groovy
@@ -37,6 +37,8 @@ class FreelineExtension {
 
     boolean retrolambdaEnabled = true
 
+    List<String> useMd5Paths = []
+
     FreelineExtension(Project project) {
     }
 }

--- a/gradle/src/main/groovy/com/antfortune/freeline/FreelineInitializer.groovy
+++ b/gradle/src/main/groovy/com/antfortune/freeline/FreelineInitializer.groovy
@@ -28,6 +28,7 @@ class FreelineInitializer {
         def extraResourcesDependencies = extension.extraResourceDependencyPaths
         def excludeResourceDependencyPaths = extension.excludeResourceDependencyPaths
         def autoDependency = extension.autoDependency
+        def useMd5Paths = extension.useMd5Paths
 
         def projectDescription = [:]
 
@@ -56,6 +57,11 @@ class FreelineInitializer {
         projectDescription.launcher = launcher
         projectDescription.apk_path = apkPath
         projectDescription.extra_dep_res_paths = extraResourcesDependencies
+        def useMd5PathArray = [];
+        for(String path : useMd5Paths){
+            useMd5PathArray.add(project.rootDir.absolutePath + File.separator + path);
+        }
+        projectDescription.use_md5_paths = useMd5PathArray
         projectDescription.exclude_dep_res_paths = excludeResourceDependencyPaths
         projectDescription.main_r_path = FreelineGenerator.generateMainRPath(projectDescription.build_directory.toString(), productFlavor, projectDescription.package.toString())
         projectDescription.use_jdk8 = isUseJdk8(projectDescription.android_gradle_plugin_version as String)


### PR DESCRIPTION
link：[Whether trigger the full compilation is determined by files which md5 value has been modified #338](https://github.com/alibaba/freeline/issues/338)
Use by:
 freeline {
        applicationProxy false
        useMd5Paths = ['build.gradle','app\\src\\main\\AndroidManifest.xml','settings.gradle']
    }
The file in useMd5Paths can be checked if it's modified or not by its MD5 Value