### PR TITLE
fix AndroidManifest has chinese characters bug

### DIFF
--- a/gradle/src/main/groovy/com/antfortune/freeline/FreelinePlugin.groovy
+++ b/gradle/src/main/groovy/com/antfortune/freeline/FreelinePlugin.groovy
@@ -535,7 +535,7 @@ class FreelinePlugin implements Plugin<Project> {
         manifest.application."@android:name" = "com.antfortune.freeline.FreelineApplication"
 
         manifestFile.delete()
-        manifestFile << XmlUtil.serialize(manifest)
+        manifestFile.write(XmlUtil.serialize(manifest), "utf-8")
     }
 
     private static int getMinSdkVersion(def mergedFlavor, String manifestPath) {


### PR DESCRIPTION
When AndroidManifest has Chinese Characters, make aapt exit with non zero. 
So need specify charset 