### PR TITLE
Kotlin incremental Support

### DIFF
--- a/freeline_core/android_tools.py
+++ b/freeline_core/android_tools.py
@@ -560,6 +560,14 @@ class AndroidIncBuildInvoker(object):
 
         return self._is_need_javac
 
+    def check_kotlinc_task(self):
+        changed_count = len(self._changed_files['kotlin'])
+        if changed_count == 0:
+            self.debug('{} project kotlin files have no change, need not go ahead'.format(self._name))
+            return False
+        else:
+            return True
+
     def _is_only_r_changed(self):
         is_only_r_changed = True
         for fpath in self._changed_files['src']:
@@ -568,6 +576,8 @@ class AndroidIncBuildInvoker(object):
             else:
                 self._is_r_file_changed = True
                 self.debug('find R.java modified in src list')
+        if len(self._changed_files['kotlin']):
+            is_only_r_changed = False
         return is_only_r_changed
 
     def fill_classpaths(self):

--- a/freeline_core/build_commands.py
+++ b/freeline_core/build_commands.py
@@ -110,6 +110,14 @@ class IncJavacCommand(MacroCommand):
         self._invoker.run_javac_task()
 
 
+class IncKotlincCommand(MacroCommand):
+    def __init__(self, pro, invoker):
+        MacroCommand.__init__(self, '{}_inc_kotlinc_compile'.format(pro))
+        self._invoker = invoker
+    def execute(self):
+        self._invoker.run_kotlinc_task()
+
+
 class IncDexCommand(MacroCommand):
     def __init__(self, pro, invoker):
         MacroCommand.__init__(self, '{}_inc_dex_compile'.format(pro))


### PR DESCRIPTION
Beta
- [x] kotlin文件增量
- [x] kotlin和java混编
- [ ] 根据gradle配置自动获取kotlin编译器
- [ ] kapt增量

需要配置kotlinc环境 （终端下可运行kotlinc的情况）
> brew update
> brew install kotlin

[官方的配置文档](https://kotlinlang.org/docs/tutorials/command-line.html)

使用：
下载zip包替换项目下的FreelineCore文件夹 
> 因为源码中sync的部分有SyncTicket的修改 会出现链接问题
> 所以可替换已有Freeline中的该文件夹
[freeline_core.zip](https://github.com/alibaba/freeline/files/1254345/freeline_core.zip)

适配过程的记录
[kotlin增量](https://life2015.github.io/2017/08/27/Freeline%E9%80%82%E9%85%8Dkotlin-2/)
