### PR TITLE
support Android Studio 3.1.x

### DIFF
--- a/freeline-studio-plugin/build.gradle
+++ b/freeline-studio-plugin/build.gradle
@@ -2,19 +2,24 @@ plugins {
     id "org.jetbrains.intellij" version "0.2.4"
 }
 
+repositories {
+    google()
+}
+
 apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'java'
 
 compileJava {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 intellij {
-    version 'IC-2016.2.5'
+    version 'IC-173.4301.25'
     pluginName 'Freeline Plugin'
     plugins = ['android', 'gradle', 'Groovy', 'terminal']
 
+    sameSinceUntilBuild = true
     // Uncomment to test against Android Studio
     // intellij.alternativeIdePath = '/Applications/Android Studio.app'
 }

--- a/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/actions/UpdateAction.java
+++ b/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/actions/UpdateAction.java
@@ -1,7 +1,7 @@
 package com.antfortune.freeline.idea.actions;
 
-import com.android.tools.idea.gradle.dsl.model.GradleBuildModel;
-import com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencyModel;
+import com.android.tools.idea.gradle.dsl.api.GradleBuildModel;
+import com.android.tools.idea.gradle.dsl.api.dependencies.ArtifactDependencyModel;
 import com.antfortune.freeline.idea.icons.PluginIcons;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;

--- a/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/icons/PluginIcons.java
+++ b/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/icons/PluginIcons.java
@@ -1,8 +1,8 @@
 package com.antfortune.freeline.idea.icons;
 
+import com.android.tools.idea.ui.Icons;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.util.IconLoader;
-import icons.AndroidIcons;
 
 import javax.swing.*;
 
@@ -35,7 +35,7 @@ public class PluginIcons {
     }
 
     private static Icon androidLoad(String path) {
-        return IconLoader.getIcon(path, AndroidIcons.class);
+        return IconLoader.getIcon(path, Icons.class);
     }
 
     private static Icon intellijLoad(String path) {

--- a/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/models/ArtifactDependencyModelWrapper.java
+++ b/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/models/ArtifactDependencyModelWrapper.java
@@ -1,6 +1,7 @@
 package com.antfortune.freeline.idea.models;
 
-import com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencyModel;
+import com.android.tools.idea.gradle.dsl.api.dependencies.ArtifactDependencyModel;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/utils/FreelineUtil.java
+++ b/freeline-studio-plugin/src/main/java/com/antfortune/freeline/idea/utils/FreelineUtil.java
@@ -1,10 +1,10 @@
 package com.antfortune.freeline.idea.utils;
 
+import com.android.tools.idea.gradle.dsl.api.GradleBuildModel;
+import com.android.tools.idea.gradle.dsl.api.dependencies.ArtifactDependencyModel;
+import com.android.tools.idea.gradle.dsl.api.dependencies.ArtifactDependencySpec;
 import com.antfortune.freeline.idea.actions.UpdateAction;
 
-import com.android.tools.idea.gradle.dsl.model.GradleBuildModel;
-import com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencyModel;
-import com.android.tools.idea.gradle.dsl.model.dependencies.ArtifactDependencySpec;
 import com.android.tools.idea.gradle.parser.GradleBuildFile;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -306,7 +306,7 @@ public class FreelineUtil {
                                     for (ArtifactDependencyModel model1 : artifactDependencyModels) {
                                         ArtifactDependencyModelWrapper wrapper = new ArtifactDependencyModelWrapper(model1);
                                         if (wrapper.group().equals(Constant.ANDROID_GRADLE_TOOL_GROUP_NAME)) {
-                                            ArtifactDependencySpec spec = new ArtifactDependencySpec(dependencyEntity.getArtifactId(),
+                                            ArtifactDependencySpec spec = ArtifactDependencySpec.create(dependencyEntity.getArtifactId(),
                                                     dependencyEntity.getGroupId(), dependencyEntity.getNewestReleaseVersion());
                                             model.buildscript().dependencies().addArtifact("classpath", spec);
                                             model.applyChanges();

--- a/freeline-studio-plugin/src/main/resources/META-INF/plugin.xml
+++ b/freeline-studio-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>com.apkfuns.plugin.freeline</id>
     <name>Freeline Plugin</name>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <vendor email="" url="https://github.com/alibaba/freeline/tree/master/android-studio-plugin">act262, 舞影凌风</vendor>
 
     <description><![CDATA[
@@ -22,10 +22,13 @@
     <change-notes><![CDATA[
       <ul>
       <li>
+          <b>1.1.5</b><br/>
+          support Android studio 3.1.x
+      </li>
+      <li>
           <b>1.1.4</b><br/>
           Add feedback channel
-        </li>
-      <li>
+      </li>
       <li>
           <b>1.1.3</b><br/>
           fix V2.3 beta2-3 crash
@@ -51,7 +54,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="141.0"/>
+    <idea-version since-build="173.0"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,4 +20,4 @@ include ':gradle'
 project(':gradle').projectDir = new File('freeline-gradle-plugin')
 
 // freeline studio plugin
-//include ':freeline-studio-plugin'
+include ':freeline-studio-plugin'


### PR DESCRIPTION
修复Android Studio 3.1.x版本 插件不能使用的问题，下载附件，解压，从硬盘安装就可以了

support Android Studio 3.1.x,  download the attachment, unzip it  and install plugin from disk

[freeline-studio-plugin.jar.zip](https://github.com/alibaba/freeline/files/1978716/freeline-studio-plugin.jar.zip)

#972 